### PR TITLE
Correct folder template for mktemp.

### DIFF
--- a/tgz2zip
+++ b/tgz2zip
@@ -44,7 +44,7 @@ fi
 
 for infile in "$@"
 do
-    unpackdir="$(mktemp -d -t 2zip)"
+    unpackdir="$(mktemp -d -t 2zip.XXXXXX)"
     trap "rm -rf '$unpackdir'" EXIT INT HUP TERM
 
     case "$infile" in


### PR DESCRIPTION
The current version crashes on Ubuntu 12.04 when the call to mktemp is made. According to MKTEMP(1) a "TEMPLATE must contain at least 3 consecutive `X's in last component".
