### PR TITLE
Message "Overwriting..."

### DIFF
--- a/tgz2zip
+++ b/tgz2zip
@@ -79,6 +79,7 @@ do
 
     if [ -e $outfile ] ; then
         echo "Overwriting $outfile" >&2
+        rm "$outfile"
     fi
     
     pushd "$unpackdir" > /dev/null


### PR DESCRIPTION
Zip called with the name of an existing file doesn't overwrite this file, but updates or adds entries. If the message is correct, the file has to be removed first, otherwise the message should be changed.
